### PR TITLE
Debug am5 updates

### DIFF
--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -6,6 +6,7 @@ import dataclasses
 from src import util, cmip6, varlist_util
 
 import logging
+
 _log = logging.getLogger(__name__)
 
 # RegexPattern that matches any string (path) that doesn't end with ".nc".
@@ -143,7 +144,8 @@ class CMIPDataSource(DataSourceBase):
     query: dict = dict(frequency="",
                        path="",
                        standard_name=""
-                      )
+                       )
+
 
 @data_source.maker
 class CESMDataSource(DataSourceBase):
@@ -157,7 +159,8 @@ class CESMDataSource(DataSourceBase):
     query: dict = dict(frequency="",
                        path="",
                        standard_name=""
-                      )
+                       )
+
 
 @data_source.maker
 class GFDLDataSource(DataSourceBase):
@@ -168,10 +171,12 @@ class GFDLDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "GFDL"
+
+    # TODO add standard_name key back to GFDL query when catalog builder is updated
     query: dict = dict(frequency="",
-                       path="",
-                       standard_name=""
-                      )
+                       path=""
+                       )
+
 
 dummy_regex = util.RegexPattern(
     r"""(?P<dummy_group>.*) # match everything; RegexPattern needs >= 1 named groups
@@ -187,9 +192,7 @@ class GlobbedDataFile:
     dummy_group: str = util.MANDATORY
     remote_path: str = util.MANDATORY
 
-
-
-    #def to_file_glob_tuple(self):
+    # def to_file_glob_tuple(self):
     #    return dm.FileGlobTuple(
     #        name=self.full_name, glob=self.glob,
     #        attrs={
@@ -197,9 +200,6 @@ class GlobbedDataFile:
     #            'pod_name': self.pod_name, 'name': self.name
     #        }
     #    )
-
-
-
 
 
 @util.mdtf_dataclass
@@ -210,7 +210,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
     # date_range: util.DateRange
     # CASE_ROOT_DIR: str
     # log: dataclasses.InitVar = _log
-    convention: str = "CMIP" # hard-code naming convention
+    convention: str = "CMIP"  # hard-code naming convention
     activity_id: str = ""
     institution_id: str = ""
     source_id: str = ""
@@ -218,8 +218,8 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
     variant_label: str = ""
     grid_label: str = ""
     version_date: str = ""
-    model: dataclasses.InitVar = ""      # synonym for source_id
-    experiment: dataclasses.InitVar = "" # synonym for experiment_id
+    model: dataclasses.InitVar = ""  # synonym for source_id
+    experiment: dataclasses.InitVar = ""  # synonym for experiment_id
     CATALOG_DIR: str = dataclasses.field(init=False)
 
     def __post_init__(self, log=_log, model=None, experiment=None):
@@ -235,7 +235,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
                         raise KeyError()
                     dest_val = cv.lookup_single(source_val, source, dest)
                     log.debug("Set %s='%s' based on %s='%s'.",
-                        dest, dest_val, source, source_val)
+                              dest, dest_val, source, source_val)
                     setattr(self, dest, dest_val)
                 except KeyError:
                     log.debug("Couldn't set %s from %s='%s'.",
@@ -248,7 +248,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
         # verify case root dir exists
         if not os.path.isdir(self.CASE_ROOT_DIR):
             log.critical("Data directory CASE_ROOT_DIR = '%s' not found.",
-                self.CASE_ROOT_DIR)
+                         self.CASE_ROOT_DIR)
             util.exit_handler(code=1)
 
         # should really fix this at the level of CLI flag synonyms
@@ -265,8 +265,8 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
             try:
                 if not cv.is_in_cv(field.name, val):
                     log.error(("Supplied value '%s' for '%s' is not recognized by "
-                        "the CMIP6 CV. Continuing, but queries will probably fail."),
-                        val, field.name)
+                               "the CMIP6 CV. Continuing, but queries will probably fail."),
+                              val, field.name)
             except KeyError:
                 # raised if not a valid CMIP6 CV category
                 continue
@@ -290,16 +290,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
             new_root = os.path.join(new_root, drs_val)
         if not os.path.isdir(new_root):
             log.error("Data directory '%s' not found; starting crawl at '%s'.",
-                new_root, self.CASE_ROOT_DIR)
+                      new_root, self.CASE_ROOT_DIR)
             self.CATALOG_DIR = self.CASE_ROOT_DIR
         else:
             self.CATALOG_DIR = new_root
-
-
-
-
-
-
-
-
-

--- a/tools/catalog_builder/catalog_builder.py
+++ b/tools/catalog_builder/catalog_builder.py
@@ -84,7 +84,7 @@ def parse_gfdl_pp_ts(file_name: str):
         table_id = ""
         assoc_files = ""
         activity_id = "GFDL"
-        institution_id = "GFDL"
+        institution_id = ""
 
         freq_opts = ['mon',
                      'day',


### PR DESCRIPTION
**Description**
-update query object defs for DataSource classes in data_sources.py
-add check for start and end time to check_group_daterange function
-refine query logic in preprocessor
-replace path_regex def with re.compile def (note that the re.compile object is passed as a list in the query object. If you don't define an re.compile object as a list when passing to the intake_esm query method, it fails)
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
