### PR TITLE
Extend alternates

### DIFF
--- a/data/fieldlist_CMIP.jsonc
+++ b/data/fieldlist_CMIP.jsonc
@@ -179,9 +179,16 @@
     },
     "pr": {
       "standard_name": "precipitation_flux",
-      "realm": ["atmos", "ocean", "seaIce"],
+      "realm": "atmos",
       "units": "kg m-2 s-1",
       "alternate_standard_names": ["rainfall_flux"],
+      "ndim": 3
+    },
+    "rainfall_flux": {
+      "standard_name": "rainfall_flux",
+      "realm": "seaIce",
+      "units": "kg m-2 s-1",
+      "alternate_standard_names": ["precipitation_flux"],
       "ndim": 3
     },
     "prc": {

--- a/data/fieldlist_CMIP.jsonc
+++ b/data/fieldlist_CMIP.jsonc
@@ -179,8 +179,9 @@
     },
     "pr": {
       "standard_name": "precipitation_flux",
-      "realm": "atmos",
+      "realm": ["atmos", "ocean", "seaIce"],
       "units": "kg m-2 s-1",
+      "alternate_standard_names": ["rainfall_flux"],
       "ndim": 3
     },
     "prc": {

--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -186,28 +186,12 @@
       "scalar_coord_templates": {"plev": "omega{value}"},
       "ndim": 4
     },
-    // NOTE: pr is the same for sea Ice and ocean realms, and there are duplicate entries;
-    // TODO: refine realm entry parsing in framework to allow lists and strings
-    "pr": {
-      "standard_name": "rainfall_flux",
-      "long_name": "Surface Rainfall Rate into the Sea Ice Portion of the Grid Cell",
-      "realm": "seaIce",
-      "units": "kg m-2 s-1",
-      "ndim": 3
-    },
-    "pr": {
-      "standard_name": "rainfall_flux",
-      "long_name": "Surface Rainfall Rate into the Sea Ice Portion of the Grid Cell",
-      "realm": "ocean",
-      "units": "kg m-2 s-1",
-      "ndim": 3
-    },
-   
     "precip": {
       "standard_name": "precipitation_flux",
       "long_name":"",
-      "realm": "atmos",
+      "realm": ["atmos", "ocean", "seaIce"],
       "units": "kg m-2 s-1",
+      "alternate_standard_names": ["rainfall_flux"],
       "ndim": 3
     },
     "prec_conv": {

--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -189,9 +189,16 @@
     "precip": {
       "standard_name": "precipitation_flux",
       "long_name":"",
-      "realm": ["atmos", "ocean", "seaIce"],
+      "realm": "atmos",
       "units": "kg m-2 s-1",
       "alternate_standard_names": ["rainfall_flux"],
+      "ndim": 3
+    },
+    "rainfall_flux": {
+      "standard_name": "rainfall_flux",
+      "realm": "seaIce",
+      "units": "kg m-2 s-1",
+      "alternate_standard_names": ["precipitation_flux"],
       "ndim": 3
     },
     "prec_conv": {

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -126,6 +126,12 @@ class AbstractDMDependentVariable(abc.ABC):
         """
         pass
 
+    @property
+    @abc.abstractmethod
+    def alternate_standard_names(self):
+        """Optional list of alternate variable standard_names to query"""
+        pass
+
 
 class AbstractDMCoordinateBounds(AbstractDMDependentVariable):
     """Defines interface (set of attributes) for :class:`DMCoordinateBounds`
@@ -764,6 +770,7 @@ class DMDependentVariable(_DMDimensionsMixin, AbstractDMDependentVariable):
     component: str = ""
     associated_files: str = ""
     rename_coords: bool = True
+    alternate_standard_names: list
 
     # dims: from _DMDimensionsMixin
     # scalar_coords: from _DMDimensionsMixin
@@ -860,8 +867,16 @@ class DMDependentVariable(_DMDimensionsMixin, AbstractDMDependentVariable):
         return self._realm
 
     @realm.setter
-    def realm(self, value: str):
+    def realm(self, value: str | list):
         self._realm = value
+
+    @property
+    def alternate_standard_names(self):
+        return self._alternate_standard_names
+
+    @alternate_standard_names.setter
+    def alternate_standard_names(self, value: list):
+        self._alternate_standard_names = value
 
     def add_scalar(self, ax, ax_value, **kwargs):
         """Metadata operation corresponding to taking a slice of a higher-dimensional

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -931,6 +931,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 if var.translation.convention is not None:
                     var_id = var.translation.name
                     standard_name = var.translation.standard_name
+                    if any(var.translation.alternate_standard_names):
+                        standard_name = [var.translation.standard_name] + var.translation.alternate_standard_names
                     date_range = var.translation.T.range
                 if var.is_static:
                     date_range = None

--- a/src/translation.py
+++ b/src/translation.py
@@ -146,22 +146,19 @@ class Fieldlist:
 
     def to_CF_standard_name(self, standard_name: str,
                             long_name: str,
-                            realm: str | list,
+                            realm: str,
                             modifier: str) -> str:
 
         precip_vars = ['precipitation_rate', 'precipitation_flux']
         # search the lookup table for the variable with the specified standard_name
         # realm, modifier, and long_name attributes
-        if isinstance(realm, str):
-            realm_list = [realm]
-        else:
-            realm_list = realm
+
         for var_name, var_dict in self.lut.items():
             if var_dict['standard_name'] == standard_name \
-                    and var_dict['realm'] in realm_list\
+                    and var_dict['realm'] == realm\
                     and var_dict['modifier'] == modifier:
                 # if not var_dict['long_name'] or var_dict['long_name'].lower() == long_name.lower():
-                    return var_name
+                return var_name
             else:
                 if var_dict['standard_name'] in precip_vars and standard_name in precip_vars:
                     return var_name
@@ -170,7 +167,7 @@ class Fieldlist:
 
     def from_CF(self,
                 standard_name: str,
-                realm: str | list,
+                realm: str,
                 modifier: str = "",
                 long_name: str = "",
                 num_dims: int = 0,
@@ -182,7 +179,7 @@ class Fieldlist:
         TODO: expand with more ways to uniquely identify variable (eg cell methods).
         Args:
             standard_name: variable or name of the variable
-            realm: str or list of strings, variable realm (atmos, ocean, land, ice, etc...)
+            realm: str variable realm (atmos, ocean, land, seaIce, etc...)
             modifier:optional string to distinguish a 3-D field from a 4-D field with
             the same var_or_name value
             long_name: str (optional) long name attribute of the variable
@@ -195,12 +192,8 @@ class Fieldlist:
         # self.lut corresponds to POD convention
         assert standard_name in self.lut_standard_names, f'{standard_name} not found in Fieldlist lut_standard_names'
         lut1 = dict()
-        if isinstance(realm, str):
-           realm_list = [realm]
-        else:
-            realm_list = realm
         for k, v in self.lut.items():
-            if v['standard_name'] == standard_name and v['realm'] in realm_list and v['modifier'] == modifier:
+            if v['standard_name'] == standard_name and v['realm'] == realm and v['modifier'] == modifier:
                 if 'long_name' not in v or v['long_name'].strip('') == '':
                     v['long_name'] = long_name
                 v['name'] = k
@@ -216,7 +209,7 @@ class Fieldlist:
 
     def from_CF_name(self,
                      var_or_name: str,
-                     realm: str | list ,
+                     realm: str,
                      long_name: str = "",
                      modifier: str = "") -> dict:
         """Like :meth:`from_CF`, but only return the variable's name in this
@@ -224,7 +217,7 @@ class Fieldlist:
 
         Args:
             var_or_name: str, variable or name of the variable
-            realm str or list of strings : model realm of variable
+            realm: str model realm of variable
             long_name: str (optional): long_name attribute of the variable
             modifier:optional string to distinguish a 3-D field from a 4-D field with
             the same var_or_name value
@@ -263,7 +256,7 @@ class Fieldlist:
         # construct convention's name for this variable on a level
         name_template = self.scalar_coord_templates[var_id][key]
         if new_coord.units.strip('').lower() == 'pa':
-            val = int(new_coord.value/100)
+            val = int(new_coord.value / 100)
         else:
             val = int(new_coord.value)
 
@@ -314,8 +307,8 @@ class Fieldlist:
                             lut_val = v.get('value')
                             if isinstance(coord.value, int) and isinstance(lut_val, str):
                                 v_int = int(float(lut_val))
-                                if v_int > coord.value and v_int/coord.value == 100 \
-                                        or v_int < coord.value and coord.value/v_int == 100 or \
+                                if v_int > coord.value and v_int / coord.value == 100 \
+                                        or v_int < coord.value and coord.value / v_int == 100 or \
                                         v_int == coord.value:
                                     new_coord = v
                                     break
@@ -386,7 +379,6 @@ class Fieldlist:
             from_convention_tl = VariableTranslator().get_convention(from_convention)
             # Fieldlist entry for POD variable
             long_name = self.get_variable_long_name(var, has_scalar_coords)
-
             fl_entries = from_convention_tl.from_CF(var.standard_name,
                                                     var.realm,
                                                     var.modifier,
@@ -465,7 +457,7 @@ class NoTranslationFieldlist(metaclass=util.Singleton):
 
     def from_CF(self,
                 var_or_name: str,
-                realm: str | list,
+                realm: str,
                 modifier=None,
                 long_name=None,
                 num_dims: int = 0,
@@ -609,11 +601,11 @@ class VariableTranslator(metaclass=util.Singleton):
                                       name_only,
                                       modifier=modifier)
 
-    def from_CF_name(self, conv_name: str, standard_name: str, realm: str | list, modifier=None):
+    def from_CF_name(self, conv_name: str, standard_name: str, realm: str, modifier=None):
         return self._fieldlist_method(conv_name, 'from_CF_name',
                                       standard_name, realm, modifier=modifier)
 
-    def to_CF_standard_name(self, conv_name: str, standard_name: str, realm: str | list, modifier=None):
+    def to_CF_standard_name(self, conv_name: str, standard_name: str, realm: str, modifier=None):
         return self._fieldlist_method(conv_name, 'to_CF_standard_name',
                                       standard_name, realm, modifier=modifier)
 

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -560,7 +560,8 @@ class Varlist(data_model.DMDataSet):
         v.dest_path = self.variable_dest_path(model_paths, case_name, v)
         try:
             trans_v = translate.translate(v, from_convention)
-            assert trans_v is not None, f'translation for varlistentry {v.name} failed'
+            if trans_v is None:
+                v.log.error(f'translation for varlistEntry {v.name} failed')
             v.translation = trans_v
             # copy preferred gfdl post-processing component during translation
             if hasattr(trans_v, "component"):


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
